### PR TITLE
LUT-32617: Anchor generated friendly URL rewrite rules to avoid prefix matching

### DIFF
--- a/webapp/WEB-INF/templates/admin/plugins/seo/urlrewrite.xml
+++ b/webapp/WEB-INF/templates/admin/plugins/seo/urlrewrite.xml
@@ -23,7 +23,7 @@
     </#list>
     <#list url_list as url>
         <rule>
-            <from>^${url.friendlyUrl}</from>
+            <from>^${url.friendlyUrl}$</from>
             <to>${url.technicalUrl?xml}</to>
         </rule>
     </#list>


### PR DESCRIPTION
…hing

The generated <from> patterns were anchored only at the start (^) but not at the end. UrlRewriteFilter (Tuckey) therefore matched them as a prefix and appended the remaining path: e.g. /wiki/git-ci-git matched the shorter rule ^/wiki/git and was rewritten to wiki_page=git-ci-git, sending a book code to the page view (ClassCastException / wrong page). Anchor the friendly URL pattern with $ so each rule matches its exact path.